### PR TITLE
fix: make after_migrate hooks non-fatal

### DIFF
--- a/aws_integration/s3/setup.py
+++ b/aws_integration/s3/setup.py
@@ -4,6 +4,17 @@ from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 
 def after_migrate():
     """Create custom fields on File DocType for S3 integration."""
+    try:
+        _create_s3_custom_fields()
+    except Exception:
+        frappe.log_error(
+            title="aws_integration after_migrate failed",
+            message=frappe.get_traceback(),
+        )
+        frappe.logger("aws_integration").exception("after_migrate failed")
+
+
+def _create_s3_custom_fields():
     custom_fields = {
         "File": [
             {


### PR DESCRIPTION
## Summary\n- wrap after_migrate work in try/except blocks\n- log full tracebacks when hook/step failures occur\n- keep migrations/deployments from failing due to non-critical after_migrate errors\n\n## Validation\n- python3 -m py_compile on the changed Python files